### PR TITLE
feat: 회의록 단건 조회 구현 및 회의록 목록 조회 성능 개선

### DIFF
--- a/src/main/java/summarybuddy/server/attendees/repository/AttendeesRepository.java
+++ b/src/main/java/summarybuddy/server/attendees/repository/AttendeesRepository.java
@@ -2,9 +2,12 @@ package summarybuddy.server.attendees.repository;
 
 import java.util.List;
 import summarybuddy.server.attendees.repository.domain.Attendees;
+import summarybuddy.server.report.dto.SimpleReport;
 
 public interface AttendeesRepository {
     List<Attendees> findAllByMemberId(Long memberId);
 
     void saveAll(List<Attendees> attendees);
+
+    List<SimpleReport> findSimpleReportsByMemberId(Long memberId);
 }

--- a/src/main/java/summarybuddy/server/attendees/repository/AttendeesRepositoryImpl.java
+++ b/src/main/java/summarybuddy/server/attendees/repository/AttendeesRepositoryImpl.java
@@ -4,11 +4,15 @@ import static summarybuddy.server.attendees.repository.domain.QAttendees.attende
 import static summarybuddy.server.member.repository.domain.QMember.member;
 import static summarybuddy.server.report.repository.domain.QReport.report;
 
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import summarybuddy.server.attendees.repository.domain.Attendees;
+import summarybuddy.server.report.dto.SimpleReport;
 
 @Repository
 @RequiredArgsConstructor
@@ -31,5 +35,26 @@ public class AttendeesRepositoryImpl implements AttendeesRepository {
     @Override
     public void saveAll(List<Attendees> attendees) {
         attendeesJpaRepository.saveAll(attendees);
+    }
+
+    @Override
+    public List<SimpleReport> findSimpleReportsByMemberId(Long memberId) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                SimpleReport.class,
+                                report.id.as("id"),
+                                Expressions.dateTemplate(
+                                                String.class,
+                                                "DATE_FORMAT({0}, {1})",
+                                                report.createdAt,
+                                                ConstantImpl.create("%m%d 회의록"))
+                                        .as("previewTitle"),
+                                report.content.substring(0, 200).as("previewContent")))
+                .from(attendees)
+                .join(attendees.report, report)
+                .join(attendees.member, member)
+                .where(attendees.member.id.eq(memberId))
+                .fetch();
     }
 }

--- a/src/main/java/summarybuddy/server/attendees/service/AttendeesService.java
+++ b/src/main/java/summarybuddy/server/attendees/service/AttendeesService.java
@@ -7,8 +7,9 @@ import summarybuddy.server.attendees.repository.AttendeesRepository;
 import summarybuddy.server.attendees.repository.domain.Attendees;
 import summarybuddy.server.member.repository.MemberRepository;
 import summarybuddy.server.member.repository.domain.Member;
+import summarybuddy.server.report.dto.SimpleReport;
 import summarybuddy.server.report.dto.request.ReportCreateRequest;
-import summarybuddy.server.report.dto.response.ReportResponse;
+import summarybuddy.server.report.dto.response.SimpleReportResponse;
 import summarybuddy.server.report.repository.domain.Report;
 
 @Service
@@ -17,9 +18,9 @@ public class AttendeesService {
     private final MemberRepository memberRepository;
     private final AttendeesRepository attendeesRepository;
 
-    public List<ReportResponse> findReportsByMemberId(Long memberId) {
-        List<Attendees> attendees = attendeesRepository.findAllByMemberId(memberId);
-        return attendees.stream().map(item -> ReportResponse.of(item.getReport())).toList();
+    public List<SimpleReportResponse> findReportsByMemberId(Long memberId) {
+        List<SimpleReport> reports = attendeesRepository.findSimpleReportsByMemberId(memberId);
+        return reports.stream().map(SimpleReportResponse::of).toList();
     }
 
     public void save(Long memberId, Report report, ReportCreateRequest request) {

--- a/src/main/java/summarybuddy/server/report/controller/ReportController.java
+++ b/src/main/java/summarybuddy/server/report/controller/ReportController.java
@@ -34,4 +34,10 @@ public class ReportController {
         List<ReportResponse> response = attendeesService.findReportsByMemberId(memberId);
         return ResponseEntity.ok().body(response);
     }
+
+    @GetMapping("/{reportId}")
+    public ResponseEntity<ReportResponse> read(@PathVariable("reportId") Long reportId) {
+        ReportResponse response = reportService.findById(reportId);
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/summarybuddy/server/report/controller/ReportController.java
+++ b/src/main/java/summarybuddy/server/report/controller/ReportController.java
@@ -9,6 +9,7 @@ import summarybuddy.server.attendees.service.AttendeesService;
 import summarybuddy.server.common.annotation.LoginMember;
 import summarybuddy.server.report.dto.request.ReportCreateRequest;
 import summarybuddy.server.report.dto.response.ReportResponse;
+import summarybuddy.server.report.dto.response.SimpleReportResponse;
 import summarybuddy.server.report.repository.domain.Report;
 import summarybuddy.server.report.service.ReportService;
 
@@ -30,8 +31,8 @@ public class ReportController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ReportResponse>> readAll(@LoginMember Long memberId) {
-        List<ReportResponse> response = attendeesService.findReportsByMemberId(memberId);
+    public ResponseEntity<List<SimpleReportResponse>> readAll(@LoginMember Long memberId) {
+        List<SimpleReportResponse> response = attendeesService.findReportsByMemberId(memberId);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/summarybuddy/server/report/dto/SimpleReport.java
+++ b/src/main/java/summarybuddy/server/report/dto/SimpleReport.java
@@ -1,0 +1,3 @@
+package summarybuddy.server.report.dto;
+
+public record SimpleReport(Long id, String previewTitle, String previewContent) {}

--- a/src/main/java/summarybuddy/server/report/dto/response/SimpleReportResponse.java
+++ b/src/main/java/summarybuddy/server/report/dto/response/SimpleReportResponse.java
@@ -1,0 +1,10 @@
+package summarybuddy.server.report.dto.response;
+
+import summarybuddy.server.report.dto.SimpleReport;
+
+public record SimpleReportResponse(Long id, String previewTitle, String previewContent) {
+    public static SimpleReportResponse of(SimpleReport report) {
+        return new SimpleReportResponse(
+                report.id(), report.previewTitle(), report.previewContent());
+    }
+}

--- a/src/main/java/summarybuddy/server/report/repository/ReportRepository.java
+++ b/src/main/java/summarybuddy/server/report/repository/ReportRepository.java
@@ -1,7 +1,10 @@
 package summarybuddy.server.report.repository;
 
+import java.util.Optional;
 import summarybuddy.server.report.repository.domain.Report;
 
 public interface ReportRepository {
     Report save(Report report);
+
+    Optional<Report> findById(Long reportId);
 }

--- a/src/main/java/summarybuddy/server/report/repository/ReportRepositoryImpl.java
+++ b/src/main/java/summarybuddy/server/report/repository/ReportRepositoryImpl.java
@@ -1,5 +1,6 @@
 package summarybuddy.server.report.repository;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import summarybuddy.server.report.repository.domain.Report;
@@ -12,5 +13,10 @@ public class ReportRepositoryImpl implements ReportRepository {
     @Override
     public Report save(Report report) {
         return reportJpaRepository.save(report);
+    }
+
+    @Override
+    public Optional<Report> findById(Long reportId) {
+        return reportJpaRepository.findById(reportId);
     }
 }

--- a/src/main/java/summarybuddy/server/report/service/ReportService.java
+++ b/src/main/java/summarybuddy/server/report/service/ReportService.java
@@ -9,6 +9,7 @@ import summarybuddy.server.ai.GoogleClient;
 import summarybuddy.server.member.repository.MemberRepository;
 import summarybuddy.server.member.repository.domain.Member;
 import summarybuddy.server.report.dto.request.ReportCreateRequest;
+import summarybuddy.server.report.dto.response.ReportResponse;
 import summarybuddy.server.report.mapper.ReportMapper;
 import summarybuddy.server.report.repository.ReportRepository;
 import summarybuddy.server.report.repository.domain.Report;
@@ -33,5 +34,13 @@ public class ReportService {
         String summary = googleClient.getSummary(result, participants);
         Report report = ReportMapper.from(summary, audioUrl); // pdf file url로 변경 필요
         return reportRepository.save(report);
+    }
+
+    public ReportResponse findById(Long reportId) {
+        Report report =
+                reportRepository
+                        .findById(reportId)
+                        .orElseThrow(() -> new RuntimeException("REPORT NOT FOUND"));
+        return ReportResponse.of(report);
     }
 }


### PR DESCRIPTION
**Descipription**
- 회의록 단건 조회를 구현하였습니다.
- 회의록 목록 조회 시 모든 데이터를 불러오지 않는 방식으로 추가 구현하였습니다.
<img width="834" alt="Screenshot 2024-09-26 at 15 15 20" src="https://github.com/user-attachments/assets/6a3ef36e-43a8-449c-84f3-ae091fe66c05">
<img width="839" alt="Screenshot 2024-09-26 at 15 33 34" src="https://github.com/user-attachments/assets/e83ea099-6071-4a5c-b7d9-a38e141fbc5b">