### PR TITLE
fix: 오디오 포맷 고정하여 인식 불가 오류 해결

### DIFF
--- a/src/main/java/summarybuddy/server/ai/GoogleClient.java
+++ b/src/main/java/summarybuddy/server/ai/GoogleClient.java
@@ -8,7 +8,8 @@ import com.google.cloud.speech.v1.*;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.util.List;
-import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +56,13 @@ public class GoogleClient {
             byte[] audioBytes = file.getBytes();
             //            ByteString audioData = ByteString.copyFrom(audioBytes);
             ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(audioBytes);
-            AudioFileFormat format = AudioSystem.getAudioFileFormat(byteArrayInputStream);
+            AudioFormat audioFormat =
+                    new AudioFormat(
+                            AudioFormat.Encoding.PCM_FLOAT, 16000.0F, 32, 1, 4, 16000.0F, false);
+            AudioInputStream format =
+                    AudioSystem.getAudioInputStream(
+                            audioFormat,
+                            new AudioInputStream(byteArrayInputStream, audioFormat, 1L));
             log.info("Audio Format: {}", format.getFormat());
 
             RecognitionAudio recognitionAudio =


### PR DESCRIPTION
**Description**
- AudioSystem 객체에서 프론트로부터 받은 오디오 파일의 포맷을 받아내지 못해 UnsupportedAudioFileException이 발생하는 문제가 있었습니다.
  <img width="623" alt="Screenshot 2024-09-29 at 20 37 40" src="https://github.com/user-attachments/assets/f4f65800-286b-483f-90e7-4a6be5f9bae7">
- 받아오는 오디오 포맷을 고정함으로써 해결하였습니다.